### PR TITLE
Fix TLS/HSTS check bugs and add 26 tests for TLS category

### DIFF
--- a/hapr/data/checks/tls.yaml
+++ b/hapr/data/checks/tls.yaml
@@ -131,6 +131,7 @@
   title: HSTS Header Configured
   category: tls
   tier: level1
+  requires_mode: http
   severity: high
   weight: 7
   description: >


### PR DESCRIPTION
## Summary

- **Fix 4 bugs** in the TLS category (HAPR-TLS-006 HSTS and `_NON_FIPS_KEYWORDS`):
  - Add `requires_mode: http` to HSTS check so TCP-only configs get NOT_APPLICABLE instead of FAIL
  - Search backend sections for HSTS headers (matching the fix already applied to header checks)
  - Match `add-header` in addition to `set-header` for HSTS detection
  - Fix `_NON_FIPS_KEYWORDS` casing: `aNULL`/`eNULL` → `ANULL`/`ENULL` to match uppercased comparison
- **Add 26 new tests** covering 5 previously untested checks (TLS-001, TLS-003, TLS-004, TLS-005, TLS-007) and missing code paths for TLS-008, MTLS-001, and TLS-006
- **Update mode-aware filtering** integration test to include `HAPR-HDR-009` and `HAPR-TLS-006`

## Test plan

- [x] All 279 tests pass (`pytest tests/ -v`) with zero failures
- [x] TLS-specific filter passes: `pytest tests/test_checks.py -v -k "TLS or HSTS or cipher or FIPS or mTLS or MTLS or DH or session_ticket or OCSP"` (55 passed)
- [x] `hapr audit examples/secure.cfg` runs successfully with TLS checks loading correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)