### PR TITLE
Fix backend/frontend checks: add requires_mode, fix WAF search, add tests

### DIFF
--- a/hapr/data/checks/backend.yaml
+++ b/hapr/data/checks/backend.yaml
@@ -81,6 +81,7 @@
   title: Cookie Attributes Set Securely
   category: backend
   tier: level1
+  requires_mode: http
   severity: medium
   weight: 4
   description: >
@@ -162,6 +163,7 @@
   title: Cache Security Controls
   category: backend
   tier: level2
+  requires_mode: http
   severity: medium
   weight: 4
   description: >

--- a/hapr/data/checks/frontend.yaml
+++ b/hapr/data/checks/frontend.yaml
@@ -241,6 +241,7 @@
   title: Compression BREACH Risk Assessment
   category: frontend
   tier: level2
+  requires_mode: http
   severity: medium
   weight: 4
   description: >

--- a/hapr/framework/checks/frontend.py
+++ b/hapr/framework/checks/frontend.py
@@ -239,10 +239,11 @@ def check_waf_integration(config: HAProxyConfig) -> Finding:
         list(config.frontends)
         + list(config.backends)
         + list(config.listens)
+        + list(config.defaults)
     )
 
     for section in all_sections:
-        section_label = section.name or "(unnamed)"
+        section_label = getattr(section, "name", None) or "(unnamed)"
 
         for directive in section.directives:
             combined = f"{directive.keyword} {directive.args}"

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -106,6 +106,8 @@ backend bk_mysql
             "HAPR-REQ-001", "HAPR-REQ-002", "HAPR-REQ-003", "HAPR-REQ-004",
             "HAPR-ACL-002",
             "HAPR-FRT-003", "HAPR-FRT-004", "HAPR-FRT-005", "HAPR-FRT-006",
+            "HAPR-FRT-007", "HAPR-COMP-001",
+            "HAPR-BKD-004", "HAPR-CACHE-001",
             "HAPR-INF-001", "HAPR-INF-003",
         }
         for finding in result.findings:
@@ -2855,3 +2857,675 @@ backend bk_web
         finding = check_hsts_configured(config)
         assert finding.check_id == "HAPR-TLS-006"
         assert finding.status == Status.PASS
+
+
+# ===========================================================================
+# Backend & Frontend Category Validation Tests
+# ===========================================================================
+
+from hapr.framework.checks.backend import (
+    check_health_checks,
+    check_connection_limits,
+    check_cookie_security,
+    check_retry_redispatch,
+    check_backend_ssl_verification,
+    check_cache_security,
+)
+from hapr.framework.checks.frontend import (
+    check_frontend_connection_limits,
+    check_waf_integration,
+    check_sql_injection_protection,
+    check_xss_protection,
+    check_bind_address_restrictions,
+    check_compression_breach_risk,
+    check_proxy_protocol_restricted,
+)
+
+
+# ---------------------------------------------------------------------------
+# HAPR-BKD-001: Health Checks Configured
+# ---------------------------------------------------------------------------
+
+class TestHealthChecks:
+    """Test check_health_checks for HAPR-BKD-001."""
+
+    def test_pass_all_backends_have_check(self):
+        config = parse_string("""
+backend bk_web
+    server web1 10.0.0.1:80 check
+    server web2 10.0.0.2:80 check
+
+backend bk_api
+    option httpchk GET /health
+    server api1 10.0.0.3:8080 check
+""")
+        finding = check_health_checks(config)
+        assert finding.check_id == "HAPR-BKD-001"
+        assert finding.status == Status.PASS
+
+    def test_partial_some_backends_missing_check(self):
+        config = parse_string("""
+backend bk_web
+    server web1 10.0.0.1:80 check
+
+backend bk_api
+    server api1 10.0.0.3:8080
+""")
+        finding = check_health_checks(config)
+        assert finding.check_id == "HAPR-BKD-001"
+        assert finding.status == Status.PARTIAL
+
+    def test_fail_no_checks(self):
+        config = parse_string("""
+backend bk_web
+    server web1 10.0.0.1:80
+    server web2 10.0.0.2:80
+""")
+        finding = check_health_checks(config)
+        assert finding.check_id == "HAPR-BKD-001"
+        assert finding.status == Status.FAIL
+
+    def test_na_no_backends(self):
+        config = parse_string("""
+global
+    log /dev/log local0
+""")
+        finding = check_health_checks(config)
+        assert finding.check_id == "HAPR-BKD-001"
+        assert finding.status == Status.NOT_APPLICABLE
+
+    def test_pass_listen_section_with_check(self):
+        config = parse_string("""
+listen my_app
+    bind *:80
+    server web1 10.0.0.1:80 check
+""")
+        finding = check_health_checks(config)
+        assert finding.check_id == "HAPR-BKD-001"
+        assert finding.status == Status.PASS
+
+
+class TestBackendConnectionLimits:
+    """Test check_connection_limits for HAPR-BKD-002."""
+
+    def test_pass_maxconn_on_servers(self):
+        config = parse_string("""
+backend bk_web
+    server web1 10.0.0.1:80 check maxconn 500
+""")
+        finding = check_connection_limits(config)
+        assert finding.check_id == "HAPR-BKD-002"
+        assert finding.status == Status.PASS
+
+    def test_pass_fullconn_directive(self):
+        config = parse_string("""
+backend bk_web
+    fullconn 1000
+    server web1 10.0.0.1:80 check
+""")
+        finding = check_connection_limits(config)
+        assert finding.check_id == "HAPR-BKD-002"
+        assert finding.status == Status.PASS
+
+    def test_fail_no_limits(self):
+        config = parse_string("""
+backend bk_web
+    server web1 10.0.0.1:80 check
+""")
+        finding = check_connection_limits(config)
+        assert finding.check_id == "HAPR-BKD-002"
+        assert finding.status == Status.FAIL
+
+    def test_na_no_backends(self):
+        config = parse_string("""
+global
+    log /dev/log local0
+""")
+        finding = check_connection_limits(config)
+        assert finding.check_id == "HAPR-BKD-002"
+        assert finding.status == Status.NOT_APPLICABLE
+
+    def test_pass_listen_section(self):
+        config = parse_string("""
+listen my_app
+    bind *:80
+    server web1 10.0.0.1:80 check maxconn 500
+""")
+        finding = check_connection_limits(config)
+        assert finding.check_id == "HAPR-BKD-002"
+        assert finding.status == Status.PASS
+
+
+class TestBackendSSLAdditional:
+    """Additional tests for check_backend_ssl (HAPR-BKD-003)."""
+
+    def test_fail_no_ssl(self):
+        config = parse_string("""
+backend bk_web
+    server web1 10.0.0.1:80 check
+""")
+        finding = check_backend_ssl(config)
+        assert finding.check_id == "HAPR-BKD-003"
+        assert finding.status == Status.FAIL
+
+    def test_partial_mixed_ssl_and_non_ssl(self):
+        config = parse_string("""
+backend bk_web
+    server web1 10.0.0.1:443 ssl check
+    server web2 10.0.0.2:80 check
+""")
+        finding = check_backend_ssl(config)
+        assert finding.check_id == "HAPR-BKD-003"
+        assert finding.status == Status.PARTIAL
+
+    def test_na_no_servers(self):
+        config = parse_string("""
+global
+    log /dev/log local0
+""")
+        finding = check_backend_ssl(config)
+        assert finding.check_id == "HAPR-BKD-003"
+        assert finding.status == Status.NOT_APPLICABLE
+
+    def test_partial_verify_none_with_non_ssl(self):
+        config = parse_string("""
+backend bk_web
+    server web1 10.0.0.1:443 ssl verify none check
+    server web2 10.0.0.2:80 check
+""")
+        finding = check_backend_ssl(config)
+        assert finding.check_id == "HAPR-BKD-003"
+        assert finding.status == Status.PARTIAL
+
+
+class TestCookieSecurity:
+    """Test check_cookie_security for HAPR-BKD-004."""
+
+    def test_pass_fully_secured(self):
+        config = parse_string("""
+backend bk_web
+    cookie SERVERID insert indirect nocache httponly secure attr SameSite=Strict
+    server web1 10.0.0.1:80 check cookie srv1
+""")
+        finding = check_cookie_security(config)
+        assert finding.check_id == "HAPR-BKD-004"
+        assert finding.status == Status.PASS
+
+    def test_partial_missing_samesite(self):
+        config = parse_string("""
+backend bk_web
+    cookie SERVERID insert indirect nocache httponly secure
+    server web1 10.0.0.1:80 check cookie srv1
+""")
+        finding = check_cookie_security(config)
+        assert finding.check_id == "HAPR-BKD-004"
+        assert finding.status == Status.PARTIAL
+
+    def test_partial_missing_secure(self):
+        config = parse_string("""
+backend bk_web
+    cookie SERVERID insert indirect nocache httponly attr SameSite=Strict
+    server web1 10.0.0.1:80 check cookie srv1
+""")
+        finding = check_cookie_security(config)
+        assert finding.check_id == "HAPR-BKD-004"
+        assert finding.status == Status.PARTIAL
+
+    def test_fail_no_security_attrs(self):
+        config = parse_string("""
+backend bk_web
+    cookie SERVERID insert indirect nocache
+    server web1 10.0.0.1:80 check cookie srv1
+""")
+        finding = check_cookie_security(config)
+        assert finding.check_id == "HAPR-BKD-004"
+        assert finding.status == Status.FAIL
+
+    def test_na_no_cookie(self):
+        config = parse_string("""
+backend bk_web
+    server web1 10.0.0.1:80 check
+""")
+        finding = check_cookie_security(config)
+        assert finding.check_id == "HAPR-BKD-004"
+        assert finding.status == Status.NOT_APPLICABLE
+
+    def test_na_no_backends(self):
+        config = parse_string("""
+global
+    log /dev/log local0
+""")
+        finding = check_cookie_security(config)
+        assert finding.check_id == "HAPR-BKD-004"
+        assert finding.status == Status.NOT_APPLICABLE
+
+
+class TestRetryRedispatch:
+    """Test check_retry_redispatch for HAPR-BKD-005."""
+
+    def test_pass_defaults_both(self):
+        config = parse_string("""
+defaults
+    retries 3
+    option redispatch
+""")
+        finding = check_retry_redispatch(config)
+        assert finding.check_id == "HAPR-BKD-005"
+        assert finding.status == Status.PASS
+
+    def test_pass_backend_both(self):
+        config = parse_string("""
+backend bk_web
+    retries 3
+    option redispatch
+    server web1 10.0.0.1:80 check
+""")
+        finding = check_retry_redispatch(config)
+        assert finding.check_id == "HAPR-BKD-005"
+        assert finding.status == Status.PASS
+
+    def test_partial_retries_only(self):
+        config = parse_string("""
+defaults
+    retries 3
+""")
+        finding = check_retry_redispatch(config)
+        assert finding.check_id == "HAPR-BKD-005"
+        assert finding.status == Status.PARTIAL
+
+    def test_partial_redispatch_only(self):
+        config = parse_string("""
+defaults
+    option redispatch
+""")
+        finding = check_retry_redispatch(config)
+        assert finding.check_id == "HAPR-BKD-005"
+        assert finding.status == Status.PARTIAL
+
+    def test_fail_neither(self):
+        config = parse_string("""
+defaults
+    mode http
+""")
+        finding = check_retry_redispatch(config)
+        assert finding.check_id == "HAPR-BKD-005"
+        assert finding.status == Status.FAIL
+
+    def test_pass_mixed_defaults_and_backend(self):
+        config = parse_string("""
+defaults
+    retries 3
+
+backend bk_web
+    option redispatch
+    server web1 10.0.0.1:80 check
+""")
+        finding = check_retry_redispatch(config)
+        assert finding.check_id == "HAPR-BKD-005"
+        assert finding.status == Status.PASS
+
+
+class TestBackendSSLVerificationAdditional:
+    """Additional tests for check_backend_ssl_verification (HAPR-BKD-006)."""
+
+    def test_partial_no_ca_file(self):
+        config = parse_string("""
+backend bk_web
+    server web1 10.0.0.1:443 ssl verify required check
+""")
+        finding = check_backend_ssl_verification(config)
+        assert finding.check_id == "HAPR-BKD-006"
+        assert finding.status == Status.PARTIAL
+
+    def test_partial_mixed(self):
+        config = parse_string("""
+backend bk_web
+    server web1 10.0.0.1:443 ssl verify required ca-file /etc/ssl/ca.pem check
+    server web2 10.0.0.2:443 ssl check
+""")
+        finding = check_backend_ssl_verification(config)
+        assert finding.check_id == "HAPR-BKD-006"
+        assert finding.status == Status.PARTIAL
+
+    def test_fail_no_verify(self):
+        config = parse_string("""
+backend bk_web
+    server web1 10.0.0.1:443 ssl check
+""")
+        finding = check_backend_ssl_verification(config)
+        assert finding.check_id == "HAPR-BKD-006"
+        assert finding.status == Status.FAIL
+
+
+class TestCacheSecurityAdditional:
+    """Additional tests for check_cache_security (HAPR-CACHE-001)."""
+
+    def test_partial_only_total_max_size(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:80
+    http-request cache-use my_cache
+    http-response cache-store my_cache
+    total-max-size 64
+""")
+        finding = check_cache_security(config)
+        assert finding.check_id == "HAPR-CACHE-001"
+        assert finding.status == Status.PARTIAL
+
+    def test_partial_only_max_age(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:80
+    http-request cache-use my_cache
+    http-response cache-store my_cache
+    max-age 3600
+""")
+        finding = check_cache_security(config)
+        assert finding.check_id == "HAPR-CACHE-001"
+        assert finding.status == Status.PARTIAL
+
+    def test_pass_cache_in_backend(self):
+        config = parse_string("""
+backend bk_web
+    http-request cache-use my_cache
+    http-response cache-store my_cache
+    total-max-size 64
+    max-age 3600
+    server web1 10.0.0.1:80 check
+""")
+        finding = check_cache_security(config)
+        assert finding.check_id == "HAPR-CACHE-001"
+        assert finding.status == Status.PASS
+
+
+class TestFrontendConnectionLimits:
+    """Test check_frontend_connection_limits for HAPR-FRT-001."""
+
+    def test_pass_maxconn(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:80
+    maxconn 10000
+""")
+        finding = check_frontend_connection_limits(config)
+        assert finding.check_id == "HAPR-FRT-001"
+        assert finding.status == Status.PASS
+
+    def test_pass_rate_limit(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:80
+    rate-limit sessions 100
+""")
+        finding = check_frontend_connection_limits(config)
+        assert finding.check_id == "HAPR-FRT-001"
+        assert finding.status == Status.PASS
+
+    def test_fail_no_limits(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:80
+    default_backend bk_web
+""")
+        finding = check_frontend_connection_limits(config)
+        assert finding.check_id == "HAPR-FRT-001"
+        assert finding.status == Status.FAIL
+
+    def test_na_no_frontends(self):
+        config = parse_string("""
+global
+    log /dev/log local0
+""")
+        finding = check_frontend_connection_limits(config)
+        assert finding.check_id == "HAPR-FRT-001"
+        assert finding.status == Status.NOT_APPLICABLE
+
+    def test_pass_listen_section(self):
+        config = parse_string("""
+listen my_app
+    bind *:80
+    maxconn 5000
+    server web1 10.0.0.1:80 check
+""")
+        finding = check_frontend_connection_limits(config)
+        assert finding.check_id == "HAPR-FRT-001"
+        assert finding.status == Status.PASS
+
+
+class TestWAFIntegrationAdditional:
+    """Additional tests for check_waf_integration (HAPR-FRT-004)."""
+
+    def test_pass_modsecurity(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:80
+    filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
+""")
+        finding = check_waf_integration(config)
+        assert finding.check_id == "HAPR-FRT-004"
+        assert finding.status == Status.PASS
+
+    def test_fail_no_waf(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:80
+    default_backend bk_web
+""")
+        finding = check_waf_integration(config)
+        assert finding.check_id == "HAPR-FRT-004"
+        assert finding.status == Status.FAIL
+
+    def test_pass_waf_in_defaults(self):
+        config = parse_string("""
+defaults
+    filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
+""")
+        finding = check_waf_integration(config)
+        assert finding.check_id == "HAPR-FRT-004"
+        assert finding.status == Status.PASS
+
+    def test_pass_waf_in_backend(self):
+        config = parse_string("""
+backend bk_web
+    filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
+    server web1 10.0.0.1:80 check
+""")
+        finding = check_waf_integration(config)
+        assert finding.check_id == "HAPR-FRT-004"
+        assert finding.status == Status.PASS
+
+
+class TestSQLInjectionProtection:
+    """Test check_sql_injection_protection for HAPR-FRT-005."""
+
+    def test_pass_direct_deny(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:80
+    http-request deny if { url_sub -i select union insert drop }
+""")
+        finding = check_sql_injection_protection(config)
+        assert finding.check_id == "HAPR-FRT-005"
+        assert finding.status == Status.PASS
+
+    def test_pass_acl_with_deny(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:80
+    acl sqli_detect url_sub -i select union insert drop update delete
+    http-request deny if sqli_detect
+""")
+        finding = check_sql_injection_protection(config)
+        assert finding.check_id == "HAPR-FRT-005"
+        assert finding.status == Status.PASS
+
+    def test_fail_no_protection(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:80
+    default_backend bk_web
+""")
+        finding = check_sql_injection_protection(config)
+        assert finding.check_id == "HAPR-FRT-005"
+        assert finding.status == Status.FAIL
+
+    def test_pass_listen_section(self):
+        config = parse_string("""
+listen my_app
+    bind *:80
+    http-request deny if { url_sub -i select union insert drop }
+    server web1 10.0.0.1:80 check
+""")
+        finding = check_sql_injection_protection(config)
+        assert finding.check_id == "HAPR-FRT-005"
+        assert finding.status == Status.PASS
+
+
+class TestXSSProtectionRules:
+    """Test check_xss_protection for HAPR-FRT-006."""
+
+    def test_pass_direct_deny(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:80
+    http-request deny if { url_sub -i <script javascript: onerror onload }
+""")
+        finding = check_xss_protection(config)
+        assert finding.check_id == "HAPR-FRT-006"
+        assert finding.status == Status.PASS
+
+    def test_pass_acl_with_deny(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:80
+    acl xss_detect url_sub -i <script javascript: onerror onload
+    http-request deny if xss_detect
+""")
+        finding = check_xss_protection(config)
+        assert finding.check_id == "HAPR-FRT-006"
+        assert finding.status == Status.PASS
+
+    def test_fail_no_protection(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:80
+    default_backend bk_web
+""")
+        finding = check_xss_protection(config)
+        assert finding.check_id == "HAPR-FRT-006"
+        assert finding.status == Status.FAIL
+
+    def test_pass_listen_section(self):
+        config = parse_string("""
+listen my_app
+    bind *:80
+    http-request deny if { url_sub -i <script javascript: onerror }
+    server web1 10.0.0.1:80 check
+""")
+        finding = check_xss_protection(config)
+        assert finding.check_id == "HAPR-FRT-006"
+        assert finding.status == Status.PASS
+
+
+class TestBindAddressRestrictionsAdditional:
+    """Additional tests for check_bind_address_restrictions (HAPR-FRT-008)."""
+
+    def test_partial_mixed(self):
+        config = parse_string("""
+frontend ft_web
+    bind 10.0.0.1:443 ssl crt /cert.pem
+
+frontend ft_admin
+    bind *:8080
+""")
+        finding = check_bind_address_restrictions(config)
+        assert finding.check_id == "HAPR-FRT-008"
+        assert finding.status == Status.PARTIAL
+
+    def test_fail_ipv6_wildcard(self):
+        config = parse_string("""
+frontend ft_web
+    bind [::]:443 ssl crt /cert.pem
+""")
+        finding = check_bind_address_restrictions(config)
+        assert finding.check_id == "HAPR-FRT-008"
+        assert finding.status == Status.FAIL
+
+    def test_pass_ipv6_specific(self):
+        config = parse_string("""
+frontend ft_web
+    bind [2001:db8::1]:443 ssl crt /cert.pem
+""")
+        finding = check_bind_address_restrictions(config)
+        assert finding.check_id == "HAPR-FRT-008"
+        assert finding.status == Status.PASS
+
+
+class TestCompressionBREACHAdditional:
+    """Additional tests for check_compression_breach_risk (HAPR-COMP-001)."""
+
+    def test_pass_no_compression(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:443 ssl crt /cert.pem
+    default_backend bk_web
+""")
+        finding = check_compression_breach_risk(config)
+        assert finding.check_id == "HAPR-COMP-001"
+        assert finding.status == Status.PASS
+
+    def test_pass_compression_on_non_ssl(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:80
+    compression algo gzip
+    default_backend bk_web
+""")
+        finding = check_compression_breach_risk(config)
+        assert finding.check_id == "HAPR-COMP-001"
+        assert finding.status == Status.PASS
+
+    def test_partial_compression_on_ssl(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:443 ssl crt /cert.pem
+    compression algo gzip
+    default_backend bk_web
+""")
+        finding = check_compression_breach_risk(config)
+        assert finding.check_id == "HAPR-COMP-001"
+        assert finding.status == Status.PARTIAL
+
+    def test_partial_defaults_compression(self):
+        config = parse_string("""
+defaults
+    compression algo gzip
+""")
+        finding = check_compression_breach_risk(config)
+        assert finding.check_id == "HAPR-COMP-001"
+        assert finding.status == Status.PARTIAL
+
+    def test_partial_backend_compression(self):
+        config = parse_string("""
+backend bk_web
+    compression algo gzip
+    server web1 10.0.0.1:80 check
+""")
+        finding = check_compression_breach_risk(config)
+        assert finding.check_id == "HAPR-COMP-001"
+        assert finding.status == Status.PARTIAL
+
+
+class TestProxyProtocolRestrictedAdditional:
+    """Additional tests for check_proxy_protocol_restricted (HAPR-PROXY-001)."""
+
+    def test_partial_non_src_acl(self):
+        config = parse_string("""
+frontend ft_web
+    bind *:443 ssl crt /cert.pem accept-proxy
+    acl is_health path /health
+    http-request deny unless is_health
+""")
+        finding = check_proxy_protocol_restricted(config)
+        assert finding.check_id == "HAPR-PROXY-001"
+        assert finding.status == Status.PARTIAL


### PR DESCRIPTION
## Summary
- Add missing `requires_mode: http` to three check definitions (HAPR-BKD-004, HAPR-CACHE-001, HAPR-COMP-001) so they correctly return N/A for TCP-only configurations instead of producing false positives
- Fix `check_waf_integration` bug where WAF directives in `defaults` sections were not detected, and use `getattr` for safe attribute access on `DefaultsSection`
- Update `http_check_ids` in `TestModeAwareFiltering` to include HAPR-FRT-007, HAPR-COMP-001, HAPR-BKD-004, and HAPR-CACHE-001
- Add 58 new tests covering all backend checks (BKD-001 through BKD-006, CACHE-001) and key frontend checks (FRT-001, FRT-004 through FRT-006, FRT-008, COMP-001, PROXY-001) with PASS, FAIL, PARTIAL, and N/A paths

## Test plan
- [x] All 58 new backend/frontend tests pass
- [x] `TestModeAwareFiltering` passes with updated `http_check_ids`
- [x] Existing tests unaffected (284 total collected, all pass)
- [ ] CI passes on Python 3.10-3.12

Generated with [Claude Code](https://claude.com/claude-code)