### PR TITLE
Fix access checks: backend search, requires_mode, test coverage

### DIFF
--- a/hapr/data/checks/access.yaml
+++ b/hapr/data/checks/access.yaml
@@ -168,6 +168,7 @@
   tier: level1
   severity: high
   weight: 7
+  requires_mode: http
   description: >
     Verify that source IP restrictions are configured on administrative interfaces,
     stats pages, and management endpoints to limit access to trusted networks.
@@ -195,6 +196,7 @@
   tier: level3
   severity: high
   weight: 7
+  requires_mode: http
   description: >
     Verify that JWT (JSON Web Token) signature verification is enforced at the proxy
     level for API gateway configurations.
@@ -222,6 +224,7 @@
   tier: level3
   severity: critical
   weight: 10
+  requires_mode: http
   description: >
     Verify that JWT configurations restrict allowed signing algorithms and prevent
     the alg:none attack vector.
@@ -248,6 +251,7 @@
   tier: level3
   severity: medium
   weight: 4
+  requires_mode: http
   description: >
     Verify that bot detection patterns are configured to filter automated traffic
     based on User-Agent and behavioral patterns.
@@ -299,6 +303,7 @@
   tier: level3
   severity: high
   weight: 7
+  requires_mode: http
   description: >
     Verify that API endpoints enforce authentication by requiring valid credentials
     before processing requests.
@@ -327,6 +332,7 @@
   tier: level3
   severity: medium
   weight: 4
+  requires_mode: http
   description: >
     Verify that API endpoints have dedicated rate limiting to prevent abuse and ensure
     fair resource allocation.

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -104,7 +104,10 @@ backend bk_mysql
             "HAPR-HDR-009",
             "HAPR-TLS-006",
             "HAPR-REQ-001", "HAPR-REQ-002", "HAPR-REQ-003", "HAPR-REQ-004",
-            "HAPR-ACL-002",
+            "HAPR-ACL-002", "HAPR-ACL-007",
+            "HAPR-JWT-001", "HAPR-JWT-002",
+            "HAPR-BOT-001",
+            "HAPR-API-001", "HAPR-API-002",
             "HAPR-FRT-003", "HAPR-FRT-004", "HAPR-FRT-005", "HAPR-FRT-006",
             "HAPR-INF-001", "HAPR-INF-003",
         }


### PR DESCRIPTION
## Summary
- Fix `check_admin_path_restricted` and `check_source_ip_restrictions` to search backend sections (in addition to frontends/listens) and use `section.get("acl")` instead of `section.acls` for Backend model compatibility
- Add `requires_mode: http` to 6 access checks that rely on HTTP-specific features: HAPR-ACL-007, HAPR-JWT-001, HAPR-JWT-002, HAPR-BOT-001, HAPR-API-001, HAPR-API-002
- Update `http_check_ids` in mode-aware filtering test to validate the new requires_mode entries are properly skipped for TCP-only configs

## Test plan
- [x] All 279 existing tests pass (0 failures)
- [x] TCP-only config correctly skips all 6 new HTTP-mode access checks as N/A
- [x] `check_admin_path_restricted` now finds admin path ACLs in backend sections
- [x] `check_source_ip_restrictions` now finds src-based ACLs in backend sections
- [x] No regressions in parser, TLS, or other check categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)