### PR TITLE
Validate remaining 11 framework categories: bug fixes and 245+ new tests

### DIFF
--- a/hapr/data/checks/access.yaml
+++ b/hapr/data/checks/access.yaml
@@ -168,6 +168,7 @@
   tier: level1
   severity: high
   weight: 7
+  requires_mode: http
   description: >
     Verify that source IP restrictions are configured on administrative interfaces,
     stats pages, and management endpoints to limit access to trusted networks.
@@ -195,6 +196,7 @@
   tier: level3
   severity: high
   weight: 7
+  requires_mode: http
   description: >
     Verify that JWT (JSON Web Token) signature verification is enforced at the proxy
     level for API gateway configurations.
@@ -222,6 +224,7 @@
   tier: level3
   severity: critical
   weight: 10
+  requires_mode: http
   description: >
     Verify that JWT configurations restrict allowed signing algorithms and prevent
     the alg:none attack vector.
@@ -248,6 +251,7 @@
   tier: level3
   severity: medium
   weight: 4
+  requires_mode: http
   description: >
     Verify that bot detection patterns are configured to filter automated traffic
     based on User-Agent and behavioral patterns.
@@ -299,6 +303,7 @@
   tier: level3
   severity: high
   weight: 7
+  requires_mode: http
   description: >
     Verify that API endpoints enforce authentication by requiring valid credentials
     before processing requests.
@@ -327,6 +332,7 @@
   tier: level3
   severity: medium
   weight: 4
+  requires_mode: http
   description: >
     Verify that API endpoints have dedicated rate limiting to prevent abuse and ensure
     fair resource allocation.

--- a/hapr/data/checks/timeouts.yaml
+++ b/hapr/data/checks/timeouts.yaml
@@ -81,6 +81,7 @@
   tier: baseline
   severity: high
   weight: 7
+  requires_mode: http
   description: >
     Verify that the HTTP request timeout (timeout http-request) is set to limit how
     long HAProxy waits for a complete HTTP request.
@@ -133,6 +134,7 @@
   tier: baseline
   severity: medium
   weight: 4
+  requires_mode: http
   description: >
     Verify that the HTTP keep-alive timeout (timeout http-keep-alive) is explicitly
     set to limit idle keep-alive connection persistence.

--- a/hapr/framework/checks/disclosure.py
+++ b/hapr/framework/checks/disclosure.py
@@ -7,6 +7,7 @@ internal architecture details, or other sensitive information to clients.
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from ...models import HAProxyConfig, Finding, Status
 
@@ -37,6 +38,8 @@ def check_server_header_removed(config: HAProxyConfig) -> Finding:
         sections.append(("defaults", d.name or "(unnamed)", d.directives))
     for fe in config.frontends:
         sections.append(("frontend", fe.name, fe.directives))
+    for be in config.backends:
+        sections.append(("backend", be.name, be.directives))
     for ls in config.listens:
         sections.append(("listen", ls.name, ls.directives))
 
@@ -55,9 +58,9 @@ def check_server_header_removed(config: HAProxyConfig) -> Finding:
                 )
                 found = True
 
-            # Modern syntax: http-response set-header Server <value>
+            # Modern syntax: http-response set-header/add-header Server <value>
             if kw == "http-response" and re.search(
-                r"set-header\s+server\b", args_lower
+                r"(?:set-header|add-header)\s+server\b", args_lower
             ):
                 evidence_parts.append(
                     f"{kind} '{name}': http-response set-header Server (custom value)"
@@ -120,6 +123,8 @@ def check_custom_error_pages(config: HAProxyConfig) -> Finding:
         sections.append(("defaults", d.name or "(unnamed)", d.directives))
     for fe in config.frontends:
         sections.append(("frontend", fe.name, fe.directives))
+    for be in config.backends:
+        sections.append(("backend", be.name, be.directives))
     for ls in config.listens:
         sections.append(("listen", ls.name, ls.directives))
 
@@ -212,6 +217,8 @@ def check_version_hidden(config: HAProxyConfig) -> Finding:
         sections.append(("defaults", d.name or "(unnamed)", d.directives))
     for fe in config.frontends:
         sections.append(("frontend", fe.name, fe.directives))
+    for be in config.backends:
+        sections.append(("backend", be.name, be.directives))
     for ls in config.listens:
         sections.append(("listen", ls.name, ls.directives))
 
@@ -301,6 +308,8 @@ def check_stats_version_hidden(config: HAProxyConfig) -> Finding:
         sections.append(("defaults", d.name or "(unnamed)", d))
     for fe in config.frontends:
         sections.append(("frontend", fe.name, fe))
+    for be in config.backends:
+        sections.append(("backend", be.name, be))
     for ls in config.listens:
         sections.append(("listen", ls.name, ls))
 
@@ -392,6 +401,8 @@ def check_xff_spoofing_prevention(config: HAProxyConfig) -> Finding:
         sections.append(("defaults", d.name or "(unnamed)", d))
     for fe in config.frontends:
         sections.append(("frontend", fe.name, fe))
+    for be in config.backends:
+        sections.append(("backend", be.name, be))
     for ls in config.listens:
         sections.append(("listen", ls.name, ls))
 

--- a/hapr/framework/checks/logging_checks.py
+++ b/hapr/framework/checks/logging_checks.py
@@ -86,6 +86,18 @@ def check_log_format(config: HAProxyConfig) -> Finding:
                     f"option httplog in frontend '{section.name}'"
                 )
 
+    # Check backends
+    for section in config.backends:
+        for directive in section.get("log-format"):
+            custom_format_parts.append(
+                f"Custom log-format in backend '{section.name}': {directive.args}"
+            )
+        for directive in section.get("option"):
+            if "httplog" in directive.args.lower():
+                httplog_parts.append(
+                    f"option httplog in backend '{section.name}'"
+                )
+
     # Check listen sections
     for section in config.listens:
         for directive in section.get("log-format"):
@@ -390,6 +402,19 @@ def check_httplog_or_tcplog(config: HAProxyConfig) -> Finding:
                     f"option tcplog in frontend '{section.name}'"
                 )
 
+    # Check backends
+    for section in config.backends:
+        for directive in section.get("option"):
+            args_lower = directive.args.lower()
+            if "httplog" in args_lower:
+                evidence_parts.append(
+                    f"option httplog in backend '{section.name}'"
+                )
+            elif "tcplog" in args_lower:
+                evidence_parts.append(
+                    f"option tcplog in backend '{section.name}'"
+                )
+
     # Check listen sections
     for section in config.listens:
         for directive in section.get("option"):
@@ -455,6 +480,14 @@ def check_dontlognull(config: HAProxyConfig) -> Finding:
             if "dontlognull" in directive.args.lower():
                 evidence_parts.append(
                     f"option dontlognull in frontend '{section.name}'"
+                )
+
+    # Check backends
+    for section in config.backends:
+        for directive in section.get("option"):
+            if "dontlognull" in directive.args.lower():
+                evidence_parts.append(
+                    f"option dontlognull in backend '{section.name}'"
                 )
 
     # Check listen sections

--- a/hapr/framework/checks/request.py
+++ b/hapr/framework/checks/request.py
@@ -307,6 +307,7 @@ def check_http_smuggling_prevention(config: HAProxyConfig) -> Finding:
 
     all_sections = (
         list(config.all_frontends_and_listens)
+        + list(config.backends)
         + list(config.defaults)
     )
 

--- a/hapr/framework/checks/tls_live.py
+++ b/hapr/framework/checks/tls_live.py
@@ -235,9 +235,11 @@ def check_secure_renegotiation_live(
         )
 
     insecure = []
+    checked = 0
     for sr in scan_results:
         if sr.error:
             continue
+        checked += 1
         if not sr.secure_renegotiation:
             insecure.append(f"{sr.target}:{sr.port} supports insecure renegotiation")
 
@@ -246,7 +248,7 @@ def check_secure_renegotiation_live(
             check_id="HAPR-SCAN-006",
             status=Status.PASS,
             message="All targets support secure renegotiation",
-            evidence=f"Checked {len(scan_results)} target(s)",
+            evidence=f"Checked {checked} target(s)",
         )
     else:
         return Finding(


### PR DESCRIPTION
## Summary

Consolidates validation of all remaining check categories after headers (PR #1) and TLS (PR #2). Covers: access, process, global_defaults, timeouts, logging, disclosure, request, tls_live, cve (backend + frontend already merged in PR #3).

### Bug fixes across 9 source files:
- **access.py**: Include backend sections in admin path and source IP checks; use `section.get("acl")` instead of `section.acls` for Backend model compatibility
- **access.yaml**: Add `requires_mode: http` to 6 HTTP-only checks (ACL-007, JWT-001/002, BOT-001, API-001/002)
- **global_defaults.py**: Fix stats socket mode comparison — was using decimal (`700 > 660`) instead of checking octal "other" permission bits
- **timeouts.py**: Add backend section search to `_find_timeout` helper (timeout server/connect commonly set per-backend)
- **timeouts.yaml**: Add `requires_mode: http` to TMO-004/TMO-006
- **disclosure.py**: Add backend iteration to all 5 disclosure checks; add `add-header` detection for Server header removal; fix missing `typing` import
- **logging_checks.py**: Add backend search to log format, httplog/tcplog, and dontlognull checks
- **request.py**: Add `config.backends` to HTTP smuggling prevention check
- **tls_live.py**: Fix secure renegotiation evidence count to exclude errored results

### Test coverage:
- ~245 new tests bringing total from **279 → 534**
- All 13 framework categories now have test coverage
- Updated mode-aware filtering integration test with all 31 HTTP-only check IDs

## Test plan
- [x] All 534 tests pass (`pytest tests/ -v`)
- [x] `hapr audit examples/secure.cfg` runs successfully
- [x] No duplicate test class names

🤖 Generated with [Claude Code](https://claude.com/claude-code)